### PR TITLE
Fixup and stylistic refactoring to match the Nextstrain code practices

### DIFF
--- a/phylogenetic/defaults/config.yaml
+++ b/phylogenetic/defaults/config.yaml
@@ -9,6 +9,8 @@
 sequences_url: "https://data.nextstrain.org/files/workflows/lassa/{segment}/sequences.fasta.zst"
 metadata_url: "https://data.nextstrain.org/files/workflows/lassa/{segment}/metadata.tsv.zst"
 
+gpc_manual_alignment: "https://raw.githubusercontent.com/JoiRichi/LASV_ML_manuscript_data/main/alignment_preprocessing/final_passed_sequences_manual_curated.fasta"
+
 strain_id_field: "accession"
 display_strain_field: "strain"
 

--- a/phylogenetic/defaults/lassa_GPC.gb
+++ b/phylogenetic/defaults/lassa_GPC.gb
@@ -34,10 +34,10 @@ FEATURES             Location/Qualifiers
                      /db_xref="taxon:3052310"
                      /segment="S"
      gene            1..1476
-                     /locus_tag="LASVsSgp2"
+                     /gene="GPC"
                      /db_xref="GeneID:956585"
      CDS             1..1476
-                     /locus_tag="LASVsSgp2"
+                     /gene="GPC"
                      /codon_start=1
                      /product="glycoprotein"
                      /protein_id="NP_694870.1"
@@ -51,7 +51,7 @@ FEATURES             Location/Qualifiers
                      QLINKAVNALINDQLIMKNHLRDIMGIPYCNYSKYWYLNHTTTGRTSLPKCWLVSNGS
                      YLNETHFSDDIEQQADNMITEMLQKEYMERQGKTPLGLVDLFVFSTSFYLISIFLHLV
                      KIPTHRHIVGKSCPKPHRLNHMGICSCGLYKQPGVPVKWKR"
-ORIGIN      
+ORIGIN
         1 atgggacaaa tagtgacatt cttccaggaa gtgcctcatg taatagaaga ggtgatgaac
        61 attgttctca ttgcactgtc tgtactagca gtgctgaaag gtctgtacaa ttttgcaacg
       121 tgtggccttg ttggtttggt cactttcctc ctgttgtgtg gtaggtcttg cacaaccagt
@@ -78,4 +78,3 @@ ORIGIN
      1381 aagtcgtgtc ccaaacctca cagattgaat catatgggca tttgttcctg tggactctac
      1441 aaacagcctg gtgtgcctgt gaaatggaag agatga
 //
-

--- a/phylogenetic/scripts/manual_curated_processor.py
+++ b/phylogenetic/scripts/manual_curated_processor.py
@@ -1,4 +1,5 @@
 from Bio import SeqIO
+import argparse
 
 def load_fasta_ids(fasta_file):
     """
@@ -24,4 +25,15 @@ def remove_already_exist(alignment_fasta, full_fasta, output_fasta):
 
     print(f"Sequences not in alignment have been written to {output_fasta}")
 
+if __name__=="__main__":
+    parser = argparse.ArgumentParser(
+        description="Find and remove existing sequences for GPC segment. This identifies new sequences that need to be passed to augur align --existing-alignment to maintain codon positions.",
+        formatter_class=argparse.ArgumentDefaultsHelpFormatter
+    )
 
+    parser.add_argument('--sequences', type=str, required=True, help="input sequences FASTA")
+    parser.add_argument('--manual-curated-alignment', type=str, required=True, help="input manually curated FASTA alignment")
+    parser.add_argument('--output-sequences', type=str, required=True, help="output new sequences FASTA")
+    args = parser.parse_args()
+
+    remove_already_exist(args.manual_curated_alignment, args.sequences, args.output_sequences)


### PR DESCRIPTION
Thanks for contributing code and manually fixed GPC alignments! I've reviewed the code-base and made some adjustments to match with Nextstrain's best practices for pathogen repositories. The GPC tree with fixed position 60 is staged at:

* https://next.nextstrain.org/staging/lassa/gpc?c=gt-GPC_60

We can work on merging this to propagate the fix to the live tree at our next meeting.